### PR TITLE
Fix sample gather bug.

### DIFF
--- a/Plugins/SGSR2/3pass/GSR/Source/src/gsr_activate.h
+++ b/Plugins/SGSR2/3pass/GSR/Source/src/gsr_activate.h
@@ -92,7 +92,7 @@ void Activate(uint2 DisThreadID)
 			float weight = Bilinweights[index];
 			Wdepth += saturate(Depthsep / (abs(fPrevdepth - depth) + EPSILON)) * weight;
 
-			float2 gPrevdepth2 = MotionDepthAlphaBuffer.GatherBlue(PointClamp2, PrevUV, sampleOffset[index + 1]).zw;
+			float2 gPrevdepth2 = MotionDepthAlphaBuffer.GatherBlue(PointClamp2, PrevUV, sampleOffset[index + 1]).xy;
 			fPrevdepth = max(max(frac(gPrevdepth2.x), frac(gPrevdepth2.y)), tdepth2);
 			Depthsep = Ksep_Kfov_diagonal * max(fPrevdepth, depth);
 			weight = Bilinweights[index + 1];


### PR DESCRIPTION
The gather sample’s clockwise is difference between HLSL and GLSL.
In GLSL(which used by your origin GSR repositories):
x y
w z
In HLSL (which used by Unreal Engine Plugin):
w z
x y
You should use the .xy to sample bottom two in Unreal.